### PR TITLE
Improve validator detail output

### DIFF
--- a/check_registration.sh
+++ b/check_registration.sh
@@ -7,6 +7,15 @@ RPC_URL="https://rpc.testnet-02.midnight.network"
 CONTAINER_NAME="midnight-shell"
 KEYS_FILE="./partner-chains-public-keys.json"
 
+# Check for optional --quiet flag
+QUIET=false
+for arg in "$@"; do
+  if [[ "$arg" == "--quiet" ]]; then
+    QUIET=true
+    break
+  fi
+done
+
 # Extract keys by executing jq inside the container
 SIDECHAIN_PUB_KEY=$(jq -r '.sidechain_pub_key' "$KEYS_FILE")
 AURA_PUB_KEY=$(jq -r '.aura_pub_key' "$KEYS_FILE")
@@ -69,27 +78,28 @@ else
   fi
 fi
 
-# Print detailed info if already registered
-if echo "$ARIADNE_RESPONSE" | jq -e ".result | .. | objects | select(.sidechainPubKey == \"$SIDECHAIN_PUB_KEY\")" > /dev/null; then
+# Print detailed info if already registered (skippable with --quiet)
+if [ "$QUIET" != "true" ] && echo "$ARIADNE_RESPONSE" | jq -e --arg key "$SIDECHAIN_PUB_KEY" '.result | .. | objects | select(.sidechainPubKey == $key)' > /dev/null; then
   echo -e "\n\033[1;34mRetrieving detailed validator information...\033[0m"
-  VALIDATOR_INFO=$(echo "$ARIADNE_RESPONSE" | jq ".result | .. | objects | select(.sidechainPubKey == \"$SIDECHAIN_PUB_KEY\")")
-  echo -e "\n\033[32m✅ Validator details found:\033[0m"
-  echo "$VALIDATOR_INFO" | jq '. | {
-    "Sidechain PubKey": .sidechainPubKey,
-    "Sidechain Account ID": .sidechainAccountId,
-    "Mainchain PubKey": .mainchainPubKey,
-    "Cross-Chain PubKey": .crossChainPubKey,
-    "Aura PubKey": .auraPubKey,
-    "Grandpa PubKey": .grandpaPubKey,
-    "Sidechain Signature": .sidechainSignature,
-    "Mainchain Signature": .mainchainSignature,
-    "Cross-Chain Signature": .crossChainSignature,
-    "UTXO ID": .utxo.utxoId,
-    "Epoch Number": .utxo.epochNumber,
-    "Block Number": .utxo.blockNumber,
-    "Slot Number": .utxo.slotNumber,
-    "Transaction Index": .utxo.txIndexWithinBlock,
-    "Stake Delegation": .stakeDelegation,
-    "Validator Status": .isValid
-  }' | jq -C
+  echo "$ARIADNE_RESPONSE" \
+    | jq -r --arg key "$SIDECHAIN_PUB_KEY" '
+      .result | .. | objects | select(.sidechainPubKey == $key) |
+      "Sidechain PubKey\t\(.sidechainPubKey)",
+      "Sidechain Account ID\t\(.sidechainAccountId)",
+      "Mainchain PubKey\t\(.mainchainPubKey)",
+      "Cross-Chain PubKey\t\(.crossChainPubKey)",
+      "Aura PubKey\t\(.auraPubKey)",
+      "Grandpa PubKey\t\(.grandpaPubKey)",
+      "Sidechain Signature\t\(.sidechainSignature)",
+      "Mainchain Signature\t\(.mainchainSignature)",
+      "Cross-Chain Signature\t\(.crossChainSignature)",
+      "UTXO ID\t\(.utxo.utxoId)",
+      "Epoch Number\t\(.utxo.epochNumber)",
+      "Block Number\t\(.utxo.blockNumber)",
+      "Slot Number\t\(.utxo.slotNumber)",
+      "Transaction Index\t\(.utxo.txIndexWithinBlock)",
+      "Stake Delegation\t\(.stakeDelegation)",
+      "Validator Status\t\(.isValid)"
+    ' \
+    | column -t -s $'\t'
 fi


### PR DESCRIPTION
## Summary
- add optional `--quiet` flag to skip verbose details
- format validator information using `jq` and `column -t`

## Testing
- `bash -n check_registration.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840bd4d3b84832596ccaaf5e63a7785